### PR TITLE
use sshd_config port + smarter swapfile creation + sleep before mn-genkey + wget only

### DIFF
--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -326,8 +326,8 @@ systemctl enable stashd
 if [ "$_masternode" == "1" ]; then
 
   # Install sentinel
-  sudo apt-get install -y git python-virtualenv
-  sudo apt-get install -y virtualenv
+  apt-get install -y git python-virtualenv
+  apt-get install -y virtualenv
   pushd ${_configPath}
   git clone ${_sentinelPath}
   pushd sentinel

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -63,7 +63,7 @@ _litemode="0"
 _debug="0"
 
 # Read SSH port from config file, otherwise default 22
-_sshd_input=$(sudo cat /etc/ssh/sshd_config | awk '/^Port/ {print $2}')
+_sshd_input=$(cat /etc/ssh/sshd_config | awk '/^Port/ {print $2}')
 re='^[0-9]+$'
 if [[ $_sshd_input =~ $re ]]; then
   # is number

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -63,11 +63,15 @@ _litemode="0"
 _debug="0"
 
 # Read SSH port from config file, otherwise default 22
-sshd_input=$(sudo cat /etc/ssh/sshd_config | awk '/^Port/ {print $2}')
-if [ $_sshd_input -le 65535 ] && [ $_sshd_input -gt 0 ]; then
-  _sshport=$_sshd_input
-else
-  _sshport="22"
+_sshd_input=$(sudo cat /etc/ssh/sshd_config | awk '/^Port/ {print $2}')
+re='^[0-9]+$'
+if [[ $_sshd_input =~ $re ]]; then
+  # is number
+  if [ $_sshd_input -le 65535 ] && [ $_sshd_input -gt 0 ]; then
+    _sshport=$_sshd_input
+  else
+    _sshport="22"
+  fi
 fi
 
 # Network variables

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -65,7 +65,7 @@ _debug="0"
 # Read SSH port from config file, otherwise default 22
 sshd_input=$(sudo cat /etc/ssh/sshd_config | awk '/^Port/ {print $2}')
 if [ $_sshd_input -le 65535 ] && [ $_sshd_input -gt 0 ]; then
-  -sshport=$_sshd_input
+  _sshport=$_sshd_input
 else
   _sshport="22"
 fi

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -68,9 +68,9 @@ re='^[0-9]+$'
 if [[ $_sshd_input =~ $re ]]; then
   # is number
   if [ $_sshd_input -le 65535 ] && [ $_sshd_input -gt 0 ]; then
-    _sshport=$_sshd_input
+    _sshPort=$_sshd_input
   else
-    _sshport="22"
+    _sshPort="22"
   fi
 fi
 

--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -72,6 +72,8 @@ if [[ $_sshd_input =~ $re ]]; then
   else
     _sshPort="22"
   fi
+else
+    _sshPort="22"
 fi
 
 # Network variables


### PR DESCRIPTION
As per tech bounty :
1. Reads existing sshd port from its system config file, if not defined defaults to port 22.
(Still writes / updates the port as before, in case someone makes a manual edit or if in the future the script is further changed to prompt user input.)  Measures have been taken to avoid input pollution (needs to be a valid number specifically in the range 1-65535).
2. Avoids creating swapfile when running inside a container, because that's technically impossible to use (and cheap VPS hosting is organised this way).  Therefor avoids wasting precious disk-space.
3. Puts "sleep 20" before masternode genkey.  Having had many attempts at setting up MN, this is the place where the script often breaks down and exists.  Shorter times have been tried, but success wasn't always achieved.

Additional : 
a. Before writing swapfile info into fstab, it's checking if the file actually got activated as swap.  If not it cleans up (again saving precious disk-space), otherwise proceeds writing the needed info into fstab.  Prevention is done with point 2, this is a catch-all for unforeseen situations.
b. Replace the 1 curl use by wget equivalent (that had 2 uses and is installed by masternode.sh) as pointed out by someone in the channel as a minor annoyance.