### PR TITLE
install_node use pidof instead of pgrep

### DIFF
--- a/scripts/install-node.sh
+++ b/scripts/install-node.sh
@@ -153,7 +153,7 @@ if [ -d ${_configPath} ]; then
     exit 1
   fi
 
-  if pgrep "${_daemon}" > /dev/null
+  if [ -n "$(pidof ${_daemon})" ];
   then
     echo "Stopping ${_daemon}..."
     killall ${_daemon} > /dev/null


### PR DESCRIPTION
The existing line matches *stashd* (e.g. status_stashd.sh) asif the daemon is running.  Though if the actual stashd daemon is not actually running, then the script will abort on killall because it can't find it.